### PR TITLE
Add 'created_date' to Session. Inferred from ObjectId

### DIFF
--- a/spec/functional/aarrr/session_spec.rb
+++ b/spec/functional/aarrr/session_spec.rb
@@ -10,6 +10,12 @@ module AARRR
         session = Session.new
         AARRR.users.count.should eq(1)
       end
+      
+      it "should load a session from a string id" do
+        session = Session.new
+        from_id = Session.new(session.id)
+        from_id.user.should_not be_nil
+      end
 
       it "should create a session with a request env" do
         session = Session.new
@@ -24,8 +30,21 @@ module AARRR
 
         AARRR.users.count.should eq(2)
       end
+      
+      it "should set the created date" do
+        just_now = Time.new.getutc - 10
+        session = Session.new
+        pp session.created_date
+        session.created_date.should be >= just_now
+      end
+      
+      it "should not change the created date when re-loading" do
+        session = Session.new        
+        second_session = Session.new(session.id)
+        session.created_date.should eql second_session.created_date
+      end
     end
-
+    
     describe "tracking" do
       before(:each) do
         @session = Session.new


### PR DESCRIPTION
Hi Guys,

As per previous message (assume you got?) I have started piecing this together to form an actual cohort reporting system.

In doing so, I noticed one key thing - we don't have the 'created date' stored with the user, so I tried to add it. Ran in to some problems since the actual hydration of the Session is always an upsert.

I didn't want to change so much, so reverted my changes back and opted for the following - simply infer it from the ObjectId and expose the property on the Session.

Would be keen to hear your thoughts.

Best,
Rob
